### PR TITLE
route-search-results: fix results not fully clickable

### DIFF
--- a/src/app/views/route-search-results/route-search-results.component.css
+++ b/src/app/views/route-search-results/route-search-results.component.css
@@ -57,7 +57,7 @@
   grid-template-rows: 1fr;
   align-items: center;
   text-align: center;
-  padding: .75rem 1.25rem;;
+  padding: .75rem 1.25rem;
 }
 
 .route-search-results__column-name {
@@ -112,7 +112,7 @@
 }
 
 ::ng-deep .card-header {
-  padding: 0rem;
+  padding: 0;
 }
 
 

--- a/src/app/views/route-search-results/route-search-results.component.css
+++ b/src/app/views/route-search-results/route-search-results.component.css
@@ -57,6 +57,7 @@
   grid-template-rows: 1fr;
   align-items: center;
   text-align: center;
+  padding: .75rem 1.25rem;;
 }
 
 .route-search-results__column-name {
@@ -108,6 +109,10 @@
   grid-row-gap: .5rem;
   align-items: center;
   text-align: center;
+}
+
+::ng-deep .card-header {
+  padding: 0rem;
 }
 
 


### PR DESCRIPTION
fixes #141 
overwrite ngbAccordions .card-header class with padding 0rem and add padding to custom .route-search-results__item-header